### PR TITLE
feat(admin): Implement Website Settings Management feature

### DIFF
--- a/src/main/java/com/papercraft/controller/admin/AdminSettingServlet.java
+++ b/src/main/java/com/papercraft/controller/admin/AdminSettingServlet.java
@@ -1,0 +1,50 @@
+package com.papercraft.controller.admin;
+
+import com.papercraft.dao.SettingDAO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+@WebServlet(name = "AdminSettingServlet", value = "/admin-setting")
+public class AdminSettingServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+        SettingDAO settingDAO = new SettingDAO();
+        request.setAttribute("settings", settingDAO.getAllSettings());
+        request.getRequestDispatcher("/WEB-INF/views/admin/admin-setting.jsp").forward(request, response);
+    }
+
+    @Override
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        request.setCharacterEncoding("UTF-8");
+        HttpSession session = request.getSession();
+        SettingDAO settingDAO = new SettingDAO();
+
+        String[] keys = {"email", "phone", "address", "working_hours", "facebook", "instagram", "twitter", "policy_privacy", "policy_terms", "policy_return", "policy_guarantee"};
+        boolean hasError = false;
+        for (String key : keys) {
+            String value = request.getParameter(key);
+
+            if (value != null) {
+                settingDAO.updateSetting(key, value);
+            } else {
+                hasError = true;
+            }
+        }
+
+        if (!hasError) {
+            session.setAttribute("successMsg", "Cập nhật thành công");
+        } else {
+            session.setAttribute("errorMsg", "Có lỗi xảy ra, vui lòng thử lại");
+        }
+
+        getServletContext().setAttribute("GLOBAL_SETTINGS", settingDAO.getAllSettings());
+        response.sendRedirect(request.getContextPath() + "/admin-setting");
+    }
+}

--- a/src/main/java/com/papercraft/dao/SettingDAO.java
+++ b/src/main/java/com/papercraft/dao/SettingDAO.java
@@ -1,0 +1,42 @@
+package com.papercraft.dao;
+
+import com.papercraft.utils.DBConnect;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SettingDAO {
+    public Map<String, String> getAllSettings() {
+        Map<String, String> settings = new HashMap<>();
+        String sql = "SELECT setting_key, setting_value FROM setting";
+
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql);
+             ResultSet rs = ps.executeQuery()) {
+            while (rs.next()) {
+                settings.put(rs.getString("setting_key"), rs.getString("setting_value"));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return settings;
+    }
+
+    public boolean updateSetting(String key, String value) {
+        String sql = "UPDATE setting SET setting_value = ? WHERE setting_key = ?";
+
+        try (Connection conn = DBConnect.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, value);
+            ps.setString(2, key);
+
+            return ps.executeUpdate() > 0;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/papercraft/listener/AppConfigListener.java
+++ b/src/main/java/com/papercraft/listener/AppConfigListener.java
@@ -1,0 +1,19 @@
+package com.papercraft.listener;
+
+import com.papercraft.dao.SettingDAO;
+import jakarta.servlet.ServletContextEvent;
+import jakarta.servlet.ServletContextListener;
+import jakarta.servlet.annotation.WebListener;
+
+@WebListener
+public class AppConfigListener implements ServletContextListener {
+    @Override
+    public void contextInitialized(ServletContextEvent sce) {
+        SettingDAO settingDAO = new SettingDAO();
+        sce.getServletContext().setAttribute("GLOBAL_SETTINGS", settingDAO.getAllSettings());
+    }
+
+    @Override
+    public void contextDestroyed(ServletContextEvent sce) {
+    }
+}

--- a/src/main/webapp/WEB-INF/views/admin/admin-setting.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/admin-setting.jsp
@@ -1,0 +1,153 @@
+<%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<!DOCTYPE html>
+<html lang="vi">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>PaperCraft - Cài Đặt Website</title>
+    <link rel="icon" href="${pageContext.request.contextPath}/images/logo.webp"/>
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
+
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/style.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/admin.css">
+    <link rel="stylesheet" href="${pageContext.request.contextPath}/css/admin-setting.css">
+
+    <script src="https://cdn.ckeditor.com/4.25.1/standard/ckeditor.js"></script>
+</head>
+
+<body>
+
+<div class="admin-container">
+
+    <jsp:include page="../includes/admin-sidebar.jsp"/>
+
+    <main class="admin-main-content">
+
+        <header class="admin-header">
+            <h1>Cài Đặt Website</h1>
+        </header>
+
+        <section class="admin-section setting-wrapper">
+
+            <c:if test="${not empty sessionScope.successMsg}">
+                <div class="alert alert-success">
+                    <i class="fa-solid fa-circle-check"></i> ${sessionScope.successMsg}
+                </div>
+                <c:remove var="successMsg" scope="session"/>
+            </c:if>
+            <c:if test="${not empty sessionScope.errorMsg}">
+                <div class="alert alert-danger">
+                    <i class="fa-solid fa-circle-exclamation"></i> ${sessionScope.errorMsg}
+                </div>
+                <c:remove var="errorMsg" scope="session"/>
+            </c:if>
+
+            <form action="${pageContext.request.contextPath}/admin-setting" method="POST" class="setting-form">
+
+                <div class="setting-card">
+                    <div class="card-header">
+                        <i class="fa-solid fa-address-book"></i> Thông tin liên hệ chung
+                    </div>
+                    <div class="card-body">
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label>Email hỗ trợ:</label>
+                                <input type="email" name="email" class="form-control" value="${settings.email}"
+                                       placeholder="VD: hotro@papercraft.com">
+                            </div>
+                            <div class="form-group">
+                                <label>Hotline / Điện thoại:</label>
+                                <input type="text" name="phone" class="form-control" value="${settings.phone}"
+                                       placeholder="VD: (+84) 123 456 789">
+                            </div>
+                            <div class="form-group full-width">
+                                <label>Địa chỉ cửa hàng:</label>
+                                <input type="text" name="address" class="form-control" value="${settings.address}">
+                            </div>
+                            <div class="form-group full-width">
+                                <label>Giờ làm việc:</label>
+                                <input type="text" name="working_hours" class="form-control"
+                                       value="${settings.working_hours}">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="setting-card">
+                    <div class="card-header">
+                        <i class="fa-solid fa-share-nodes"></i> Liên kết Mạng xã hội
+                    </div>
+                    <div class="card-body">
+                        <div class="form-grid">
+                            <div class="form-group">
+                                <label><i class="fa-brands fa-facebook" style="color:#1877F2"></i> Facebook URL:</label>
+                                <input type="url" name="facebook" class="form-control" value="${settings.facebook}">
+                            </div>
+                            <div class="form-group">
+                                <label><i class="fa-brands fa-instagram" style="color:#E4405F"></i> Instagram
+                                    URL:</label>
+                                <input type="url" name="instagram" class="form-control" value="${settings.instagram}">
+                            </div>
+                            <div class="form-group">
+                                <label><i class="fa-brands fa-twitter" style="color:#1DA1F2"></i> Twitter URL:</label>
+                                <input type="url" name="twitter" class="form-control" value="${settings.twitter}">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="setting-card">
+                    <div class="card-header">
+                        <i class="fa-solid fa-scale-balanced"></i> Nội dung Chính sách & Pháp lý
+                    </div>
+                    <div class="card-body">
+                        <div class="form-group full-width">
+                            <label>Chính sách bảo mật:</label>
+                            <textarea name="policy_privacy" id="policy_privacy"
+                                      class="form-control">${settings.policy_privacy}</textarea>
+                        </div>
+
+                        <div class="form-group full-width">
+                            <label>Điều khoản dịch vụ:</label>
+                            <textarea name="policy_terms" id="policy_terms"
+                                      class="form-control">${settings.policy_terms}</textarea>
+                        </div>
+
+                        <div class="form-group full-width">
+                            <label>Chính sách đổi trả:</label>
+                            <textarea name="policy_return" id="policy_return"
+                                      class="form-control">${settings.policy_return}</textarea>
+                        </div>
+
+                        <div class="form-group full-width">
+                            <label>Chính sách bảo hành:</label>
+                            <textarea name="policy_guarantee" id="policy_guarantee"
+                                      class="form-control">${settings.policy_guarantee}</textarea>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="form-actions">
+                    <button type="submit" class="btn-submit-setting">
+                        <i class="fa-solid fa-floppy-disk"></i> Lưu Tất Cả Cấu Hình
+                    </button>
+                </div>
+
+            </form>
+        </section>
+
+    </main>
+</div>
+
+<script>
+    CKEDITOR.replace('policy_privacy');
+    CKEDITOR.replace('policy_terms');
+    CKEDITOR.replace('policy_return');
+    CKEDITOR.replace('policy_guarantee');
+</script>
+</body>
+
+</html>

--- a/src/main/webapp/WEB-INF/views/client/contact.jsp
+++ b/src/main/webapp/WEB-INF/views/client/contact.jsp
@@ -78,7 +78,7 @@
                     </div>
                     <div class="info-text">
                         <h3 class="info-title">Email</h3>
-                        <a href="#" class="info-link">hotro@papercraft.com</a>
+                        <a href="#" class="info-link">${applicationScope.GLOBAL_SETTINGS.email}</a>
                     </div>
                 </div>
 
@@ -88,7 +88,7 @@
                     </div>
                     <div class="info-text">
                         <h3 class="info-title">Số điện thoại</h3>
-                        <a href="#" class="info-link">(+84) 123 456 789</a>
+                        <a href="#" class="info-link">${applicationScope.GLOBAL_SETTINGS.phone}</a>
                     </div>
                 </div>
 
@@ -98,7 +98,7 @@
                     </div>
                     <div class="info-text">
                         <h3 class="info-title">Địa chỉ</h3>
-                        <a href="#" class="info-link">159 QL1K, P.Đông Hòa,Dĩ An, TP.HCM</a>
+                        <a href="#" class="info-link">${applicationScope.GLOBAL_SETTINGS.address}</a>
                     </div>
                 </div>
 
@@ -108,7 +108,7 @@
                     </div>
                     <div class="info-text">
                         <h3 class="info-title">Giờ làm việc</h3>
-                        <a href="#" class="info-link">Từ thứ 2- thứ 6: 9h-18h</a>
+                        <a href="#" class="info-link">${applicationScope.GLOBAL_SETTINGS.working_hours}</a>
                     </div>
                 </div>
 

--- a/src/main/webapp/WEB-INF/views/includes/admin-sidebar.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/admin-sidebar.jsp
@@ -52,6 +52,12 @@
                     <i class="fa-solid fa-message"></i> Tin Nhắn Liên Hệ
                 </a>
             </li>
+            <li>
+                <a href="${pageContext.request.contextPath}/admin-setting"
+                   class="${fn:contains(uri, 'admin-setting') ? 'active' : ''}">
+                    <i class="fa-solid fa-gear"></i> Cài Đặt Website
+                </a>
+            </li>
         </ul>
     </nav>
 

--- a/src/main/webapp/WEB-INF/views/includes/footer.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/footer.jsp
@@ -32,15 +32,15 @@
         <div class="footer-col">
             <h4 class="footer-heading">Theo Dõi Chúng Tôi</h4>
             <div class="social-icons">
-                <a href="${applicationScope.GLOBAL_SETTINGS.facebook}" target="_blank">
+                <a href="${applicationScope.GLOBAL_SETTINGS.facebook}" target="_blank" title="Facebook">
                     <i class="fab fa-facebook-f"></i>
                 </a>
 
-                <a href="${applicationScope.GLOBAL_SETTINGS.twitter}" target="_blank">
+                <a href="${applicationScope.GLOBAL_SETTINGS.twitter}" target="_blank" title="Twitter">
                     <i class="fab fa-twitter"></i>
                 </a>
 
-                <a href="${applicationScope.GLOBAL_SETTINGS.instagram}" target="_blank">
+                <a href="${applicationScope.GLOBAL_SETTINGS.instagram}" target="_blank" title="Instagram">
                     <i class="fab fa-instagram"></i>
                 </a>
             </div>

--- a/src/main/webapp/WEB-INF/views/includes/footer.jsp
+++ b/src/main/webapp/WEB-INF/views/includes/footer.jsp
@@ -4,7 +4,7 @@
     <div class="footer-container">
         <div class="footer-col footer-col-info">
             <div class="footer-logo">
-                <img src="${pageContext.request.contextPath}/images/logo.webp" height="80" width="80" />
+                <img src="${pageContext.request.contextPath}/images/logo.webp" height="80" width="80"/>
             </div>
             <p class="footer-description">
                 Đối tác tin cậy cho máy in và văn phòng phẩm từ năm 2010.
@@ -32,9 +32,17 @@
         <div class="footer-col">
             <h4 class="footer-heading">Theo Dõi Chúng Tôi</h4>
             <div class="social-icons">
-                <i class="fab fa-facebook-f"></i>
-                <i class="fab fa-twitter"></i>
-                <i class="fab fa-instagram"></i>
+                <a href="${applicationScope.GLOBAL_SETTINGS.facebook}" target="_blank">
+                    <i class="fab fa-facebook-f"></i>
+                </a>
+
+                <a href="${applicationScope.GLOBAL_SETTINGS.twitter}" target="_blank">
+                    <i class="fab fa-twitter"></i>
+                </a>
+
+                <a href="${applicationScope.GLOBAL_SETTINGS.instagram}" target="_blank">
+                    <i class="fab fa-instagram"></i>
+                </a>
             </div>
         </div>
     </div>
@@ -43,5 +51,6 @@
         <p>&copy; 2025 PaperCraft. All rights reserved.</p>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script> <%--thư viện popup --%>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <%--thư viện popup --%>
 </footer>

--- a/src/main/webapp/css/admin-setting.css
+++ b/src/main/webapp/css/admin-setting.css
@@ -1,0 +1,139 @@
+.setting-wrapper {
+    padding: 20px 20px;
+}
+
+.setting-card {
+    background: #fff;
+    border-radius: 10px;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+    margin-bottom: 30px;
+    overflow: hidden;
+    transition: 0.2s ease;
+}
+
+.setting-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+}
+
+.card-header {
+    background-color: #f8f9fa;
+    padding: 15px 20px;
+    font-size: 16px;
+    font-weight: 600;
+    color: #333;
+    border-bottom: 1px solid #eaeaea;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.card-header i {
+    color: #555;
+}
+
+.card-body {
+    padding: 20px;
+}
+
+.form-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 15px;
+}
+
+.form-group.full-width {
+    grid-column: 1 / -1;
+}
+
+.form-group label {
+    font-weight: 600;
+    color: #444;
+    font-size: 14px;
+}
+
+.form-control {
+    padding: 10px 15px;
+    border: 1px solid #ccc;
+    border-radius: 5px;
+    font-size: 14px;
+    color: #333;
+    outline: none;
+    transition: border-color 0.3s;
+    font-family: inherit;
+}
+
+.form-control:focus {
+    border-color: #007bff;
+    box-shadow: 0 0 0 3px rgba(0, 123, 255, 0.1);
+}
+
+.form-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 10px;
+    padding-bottom: 30px;
+}
+
+.btn-submit-setting {
+    background-color: #28a745;
+    color: white;
+    padding: 12px 25px;
+    border: none;
+    border-radius: 6px;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
+    transition: background-color 0.3s, transform 0.1s;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.btn-submit-setting:hover {
+    background-color: #218838;
+}
+
+.btn-submit-setting:active {
+    transform: scale(0.97);
+}
+
+.alert {
+    padding: 15px 20px;
+    border-radius: 8px;
+    margin-bottom: 25px;
+    font-weight: 500;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    animation: fadeInDown 0.4s ease;
+}
+
+.alert-success {
+    color: #155724;
+    background-color: #d4edda;
+    border-left: 5px solid #28a745;
+}
+
+.alert-danger {
+    color: #721c24;
+    background-color: #f8d7da;
+    border-left: 5px solid #dc3545;
+}
+
+@keyframes fadeInDown {
+    from {
+        opacity: 0;
+        transform: translateY(-10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}


### PR DESCRIPTION
1. Database & Backend:

Tạo bảng setting để lưu trữ các cặp key-value cấu hình.
Thêm SettingDAO.
Thêm AdminSettingServlet.

2. Core (Khởi tạo dữ liệu):

Thêm AppConfigListener (tích hợp @WebListener) giúp tự động gọi Database để tải toàn bộ cấu hình vào biến GLOBAL_SETTINGS ngay khi Server khởi động.

3. Frontend (Giao diện Admin):

Thêm trang admin_setting.jsp để quản lý (Liên hệ, Mạng xã hội, Chính sách).
Tích hợp thành công CKEditor 4 để Admin soạn thảo văn bản phong phú cho các trang Chính sách.

4. Frontend (Giao diện Khách hàng):

Chuyển đổi các link tĩnh tĩnh trong footer.jsp, contact.jsp thành dữ liệu động lấy từ ${applicationScope.GLOBAL_SETTINGS}.