### PR TITLE
refactor: improve OTP step flow in forgot password form

### DIFF
--- a/src/main/java/com/papercraft/controller/client/ForgotPasswordServlet.java
+++ b/src/main/java/com/papercraft/controller/client/ForgotPasswordServlet.java
@@ -16,71 +16,80 @@ import java.io.IOException;
 public class ForgotPasswordServlet extends HttpServlet {
 
     protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String action = request.getParameter("action");
-        response.setContentType("text/plain; charset=UTF-8");
-
-        if ("sendOTP".equals(action)) {
-            String email = request.getParameter("email");
-            UserDAO userDAO = new UserDAO();
-            HttpSession session = request.getSession();
-
-            // Chống spam
-            Long lastCreateTime = (Long) session.getAttribute("OTP_createTime");
-            if (lastCreateTime != null && System.currentTimeMillis() - lastCreateTime < 60000) {
-                response.setStatus(429);
-                response.getWriter().write("Vui lòng đợi 60 giây trước khi yêu cầu gửi lại OTP.");
-                return;
-            }
-
-            // Kiểm tra email có trong db chưa
-            if (userDAO.checkEmailExists(email)) {
-                String otp = EmailUtils.generateOTP();
-                boolean isSent = EmailUtils.sendForgotPasswordOTP(email, otp);
-
-                if (isSent) {
-                    session.setAttribute("OTP_CODE", otp);
-                    session.setAttribute("RESET_EMAIL", email);
-                    session.setAttribute("OTP_createTime", System.currentTimeMillis());
-
-                    response.getWriter().write("Thành công");
-                } else {
-                    session.setAttribute("error", "Gửi email thất bại! Vui lòng kiểm tra lại kết nối hoặc email");
-                }
-            } else {
-                session.setAttribute("error", "Email không tồn tại trong hệ thống!");
-            }
-        } else {
-            request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
-        }
+        request.setAttribute("showOTPField", false);
+        request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
     }
 
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
-        String userOtp = request.getParameter("otp");
+        String email = request.getParameter("email");
+        String otp = request.getParameter("otp");
         HttpSession session = request.getSession();
+        UserDAO userDAO = new UserDAO();
+
+        if (otp == null) {
+            Long lastCreateTime = (Long) session.getAttribute("OTP_createTime");
+            if (lastCreateTime != null && System.currentTimeMillis() - lastCreateTime < 60000) {
+                request.setAttribute("error", "Vui lòng đợi 60 giây trước khi yêu cầu gửi lại OTP");
+                request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
+                return;
+            }
+
+            if (userDAO.checkEmailExists(email)) {
+                String genOTP = EmailUtils.generateOTP();
+                boolean isSent = EmailUtils.sendForgotPasswordOTP(email, genOTP);
+
+                if (isSent) {
+                    session.setAttribute("OTP_CODE", genOTP);
+                    session.setAttribute("RESET_EMAIL", email);
+                    session.setAttribute("OTP_createTime", System.currentTimeMillis());
+
+                    request.setAttribute("success", "Mã OTP đã được gửi đến email của bạn!");
+                    request.setAttribute("showOTPField", true);
+                } else {
+                    request.setAttribute("error", "Gửi email thất bại! Vui lòng kiểm tra lại kết nối");
+                }
+
+                request.setAttribute("email", email);
+                request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
+                return;
+            } else {
+                request.setAttribute("error", "Email không tồn tại trong hệ thống!");
+                request.setAttribute("showOTPField", false);
+                request.setAttribute("email", email);
+                request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
+                return;
+            }
+        }
+
         String systemOtp = (String) session.getAttribute("OTP_CODE");
         Long createTime = (Long) session.getAttribute("OTP_createTime");
 
         if (systemOtp == null || createTime == null) {
-            request.setAttribute("error", "Phiên giao dịch đã hết hạn hoặc không hợp lệ. Vui lòng lấy lại mã.");
+            request.setAttribute("error", "Phiên giao dịch đã hết hạn. Vui lòng lấy lại mã.");
+            request.setAttribute("email", email);
             request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
             return;
         }
 
-        if (System.currentTimeMillis() - createTime > 300000) {
+        if(System.currentTimeMillis() - createTime > 300000) {
             session.removeAttribute("OTP_CODE");
-            request.setAttribute("error", "Mã OTP đã hết hạn!");
+            request.setAttribute("error", "Mã OTP đã hết hạn! Vui lòng gửi lại mã.");
+            request.setAttribute("showOTPField", true);
+            request.setAttribute("email", email);
             request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
             return;
         }
 
-        if (systemOtp.equals(userOtp)) {
+        if (systemOtp.equals(otp)) {
             session.removeAttribute("OTP_CODE");
             session.removeAttribute("OTP_createTime");
 
             session.setAttribute("IS_VERIFIED", true);
-            response.sendRedirect("reset-password");
+            response.sendRedirect(request.getContextPath() + "/reset-password");
         } else {
-            request.setAttribute("error", "Mã OTP sai hoặc đã hết hạn!");
+            request.setAttribute("error", "Mã OTP không chính xác!");
+            request.setAttribute("showOTPField", true);
+            request.setAttribute("email", email);
             request.getRequestDispatcher("/WEB-INF/views/client/forgot-password.jsp").forward(request, response);
         }
     }

--- a/src/main/java/com/papercraft/controller/client/ResendOTPServlet.java
+++ b/src/main/java/com/papercraft/controller/client/ResendOTPServlet.java
@@ -16,10 +16,12 @@ public class ResendOTPServlet extends HttpServlet {
     protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
         response.setContentType("application/json;charset=UTF-8");
         HttpSession session = request.getSession();
-        User tempUser = (User) session.getAttribute("tempUser");
 
-        if (tempUser == null) {
-            response.getWriter().write("{\"status\": \"error\", \"message\": \"Phiên đăng ký hết hạn, vui lòng đăng ký lại!\"}");
+        User tempUser = (User) session.getAttribute("tempUser");
+        String resetEmail = (String) session.getAttribute("RESET_EMAIL");
+
+        if (tempUser == null && resetEmail == null) {
+            response.getWriter().write("{\"status\": \"error\", \"message\": \"Phiên giao dịch hết hạn, vui lòng thao tác lại!\"}");
             return;
         }
 
@@ -48,10 +50,16 @@ public class ResendOTPServlet extends HttpServlet {
         }
 
         String newOTP = EmailUtils.generateOTP();
-        boolean isSent = EmailUtils.sendRegisterOTP(tempUser.getEmail(), newOTP);
+        boolean isSent = false;
+        if (tempUser != null) {
+            isSent = EmailUtils.sendRegisterOTP(tempUser.getEmail(), newOTP);
+            if (isSent) session.setAttribute("authCode", newOTP);
+        } else if (resetEmail != null) {
+            isSent = EmailUtils.sendForgotPasswordOTP(resetEmail, newOTP);
+            if (isSent) session.setAttribute("OTP_CODE", newOTP);
+        }
 
         if (isSent) {
-            session.setAttribute("authCode", newOTP);
             session.setAttribute("OTP_resend_count", resendCount + 1);
             session.setAttribute("REG_OTP_createTime", currentTime);
             response.getWriter().write("{\"status\": \"success\", \"message\": \"Gửi lại mã thành công\"}");

--- a/src/main/webapp/WEB-INF/views/client/forgot-password.jsp
+++ b/src/main/webapp/WEB-INF/views/client/forgot-password.jsp
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <title>PaperCraft - Đăng Nhập</title>
-    <link rel="icon" href="${pageContext.request.contextPath}/images/logo.webp" />
+    <link rel="icon" href="${pageContext.request.contextPath}/images/logo.webp"/>
 
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/boxicons@latest/css/boxicons.min.css">
@@ -17,7 +17,8 @@
 <jsp:include page="../includes/header.jsp"/>
 
 <div class="form-wrapper">
-    <img src="${pageContext.request.contextPath}/images/login-bg.webp" alt="" class="login-background-image" fetchpriority="high" width="1920"
+    <img src="${pageContext.request.contextPath}/images/login-bg.webp" alt="" class="login-background-image"
+         fetchpriority="high" width="1920"
          height="1080">
     <div class="form-box">
         <div class="login-container" id="login">
@@ -37,26 +38,33 @@
                     </p>
 
                     <div class="input-box">
-                        <input type="email" class="input-field" name="email" id="emailInput" placeholder="Nhập Email đăng ký" required>
-                        <i class="bx bx-envelope"></i> </div>
+                        <input type="email" class="input-field" name="email" id="emailInput"
+                               placeholder="Nhập Email đăng ký" value="${param.email}"
+                        ${showOTPField ? 'readonly' : ''} required>
+                        <i class="bx bx-envelope"></i></div>
 
-                    <div class="input-box">
-                        <input type="text" class="input-field" name="otp" placeholder="Nhập mã OTP trong mail" required>
-                        <i class="bx bx-lock"></i>
-                    </div>
+                    <c:if test="${showOTPField}">
+                        <div class="otp-input-row">
+                            <input type="text" class="input-field" name="otp" placeholder="Nhập mã OTP trong mail"
+                                   required>
+
+                            <button type="button" class="resend-otp" id="btn-resend-otp" disabled>Gửi lại mã (30s)
+                            </button>
+                        </div>
+                    </c:if>
 
                     <div class="two-col">
                         <div class="one">
                             <label><a href="${pageContext.request.contextPath}/contact">Liên hệ giúp đỡ</a></label>
                         </div>
                         <div class="two">
-                            <label><a href="#" id="btnSendOTP">Gửi mã OTP</a></label>
-                            <span id="otpMessage" style="color: green; font-size: 12px; display: none;">Đang gửi...</span>
+                            <label><a href="${pageContext.request.contextPath}/policies-and-services">Điều khoản & Dịch
+                                vụ</a></label>
                         </div>
                     </div>
 
                     <div class="input-box">
-                        <input type="submit" class="submit" value="Xác nhận">
+                        <input type="submit" class="submit" value="${showOTPField ? 'Xác nhận' : 'Gửi mã OTP'}">
                     </div>
 
                     <p style="color:red; text-align:center; margin-top:10px;">${message}</p>
@@ -68,39 +76,56 @@
             </div>
 
             <script>
-                document.getElementById('btnSendOTP').addEventListener('click', function(e) {
-                    e.preventDefault();
-                    var email = document.getElementById('emailInput').value;
-                    var msgSpan = document.getElementById('otpMessage');
+                document.addEventListener("DOMContentLoaded", function () {
+                    const resendBtn = document.getElementById("btn-resend-otp");
+                    const statusMsg = document.getElementById("status-msg");
+                    let timer;
 
-                    if(email === "") {
-                        alert("Vui lòng nhập Email!");
-                        return;
+                    function startTimer() {
+                        let timeLeft = 30;
+                        resendBtn.disabled = true;
+                        resendBtn.style.cursor = "not-allowed";
+                        resendBtn.style.opacity = "0.7";
+
+                        timer = setInterval(() => {
+                            timeLeft--;
+                            resendBtn.innerText = "Gửi lại mã (" + timeLeft + "s)";
+
+                            if (timeLeft <= 0) {
+                                clearInterval(timer);
+                                resendBtn.disabled = false;
+                                resendBtn.style.cursor = "pointer";
+                                resendBtn.style.opacity = "1";
+                                resendBtn.innerText = "Gửi lại mã";
+                            }
+                        }, 1000);
                     }
 
-                    msgSpan.style.display = 'inline';
-                    msgSpan.style.color = '#333';
-                    msgSpan.innerText = "Đang gửi mail...";
+                    if (resendBtn) {
+                        startTimer();
+                        resendBtn.addEventListener("click", function () {
+                            resendBtn.disabled = true;
+                            resendBtn.innerText = "Đang gửi lại mã";
 
-                    // Gọi AJAX
-                    fetch('${pageContext.request.contextPath}/forgot-password?action=sendOTP&email=' + email, {
-                        method: 'GET'
-                    })
-                        .then(response => {
-                            if (response.ok) {
-                                return response.text();
-                            } else {
-                                throw new Error('Email chưa đăng ký!');
-                            }
-                        })
-                        .then(data => {
-                            msgSpan.style.color = 'green';
-                            msgSpan.innerText = "Đã gửi mã vào email!";
-                        })
-                        .catch(error => {
-                            msgSpan.style.color = 'red';
-                            msgSpan.innerText = "Email không tồn tại!";
+                            fetch("${pageContext.request.contextPath}/resend-otp", {
+                                method: "POST",
+                            }).then(response => response.json()).then(data => {
+                                statusMsg.innerHTML = data.message;
+                                if (data.status === "success") {
+                                    statusMsg.style.color = "green";
+                                    startTimer();
+                                } else {
+                                    statusMsg.style.color = "red";
+                                    if (!data.message.includes("phút")) {
+                                        resendBtn.disabled = false;
+                                    }
+                                }
+                            }).catch(error => {
+                                statusMsg.innerHTML = '<span style="color: red;">Lỗi kết nối máy chủ!</span>';
+                                resendBtn.disabled = false;
+                            })
                         });
+                    }
                 });
             </script>
         </div>

--- a/src/main/webapp/WEB-INF/views/client/forgot-password.jsp
+++ b/src/main/webapp/WEB-INF/views/client/forgot-password.jsp
@@ -1,4 +1,5 @@
 <%@ page contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <!DOCTYPE html>
 <html lang="en">
 

--- a/src/main/webapp/css/login.css
+++ b/src/main/webapp/css/login.css
@@ -224,10 +224,6 @@ header {
 .otp-input-row .input-field {
     flex: 1;
     padding: 0 15px;
-    text-align: center;
-    letter-spacing: 5px;
-    font-weight: bold;
-    font-size: 1.2rem;
 }
 
 .resend-otp {


### PR DESCRIPTION
- Refactor form to use JSTL for conditional rendering of the OTP field.
- Make email input readonly during the OTP verification step to prevent state mismatch.
- Dynamically update submit button text based on the current verification step.
- ForgotPasswordServlet: fix state logic to appropriately match UI.
- ResendOTPServlet: unify logic to support both Register and Forgot Password.

Closes #21