### PR TITLE
feat(payment): integrate VNPAY & Momo gateway, handle transaction failures, and auto-restore stock

### DIFF
--- a/1
+++ b/1
@@ -1,6 +1,0 @@
-Merge branch 'main' of https://github.com/thiethinh/TTW_BanMayInVaVatTuVanPhong into thai-dev
-# Please enter a commit message to explain why this merge is necessary,
-# especially if it merges an updated upstream into a topic branch.
-#
-# Lines starting with '#' will be ignored, and an empty message aborts
-# the commit.

--- a/src/main/java/com/papercraft/config/MomoConfig.java
+++ b/src/main/java/com/papercraft/config/MomoConfig.java
@@ -1,0 +1,73 @@
+package com.papercraft.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+
+public class MomoConfig {
+    public static final String partnerCode = "MOMOBKUN20180810";
+    public static final String accessKey = "WbU5m69vM9SllgIs";
+    public static final String secretKey = "68979a059c39bc0f6c24522cd9540026";
+
+    public static final String momo_Url = "https://test-payment.momo.vn/v2/gateway/api/create";
+
+    public static String getReturnUrl(HttpServletRequest request) {
+        String scheme = request.getScheme();
+        String serverName = request.getServerName();
+        int serverPort = request.getServerPort();
+        String contextPath = request.getContextPath();
+
+        StringBuilder url = new StringBuilder();
+        url.append(scheme).append("://").append(serverName);
+
+        if (serverPort != 80) {
+            url.append(":").append(serverPort);
+        }
+        url.append(contextPath).append("/momo-return");
+
+        return url.toString();
+    }
+
+    public static String getIpnUrl(HttpServletRequest request) {
+        String scheme = request.getScheme();
+        String serverName = request.getServerName();
+        int serverPort = request.getServerPort();
+        String contextPath = request.getContextPath();
+
+        StringBuilder url = new StringBuilder();
+        url.append(scheme).append("://").append(serverName);
+
+        if (serverPort != 80 && serverPort != 443) {
+            url.append(":").append(serverPort);
+        }
+
+        url.append(contextPath).append("/momo-ipn");
+        return url.toString();
+    }
+
+    public static String hcmacSHA256(String key, String data) {
+        try {
+            if (key == null || data == null) {
+                throw new Exception();
+            }
+
+            Mac hcmacSHA256 = Mac.getInstance("HmacSHA256");
+            SecretKeySpec secretKey = new SecretKeySpec(key.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+            hcmacSHA256.init(secretKey);
+
+            byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+            byte[] result = hcmacSHA256.doFinal(dataBytes);
+
+            StringBuilder sb = new StringBuilder();
+            for (byte b : result) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+}

--- a/src/main/java/com/papercraft/config/VNPAYConfig.java
+++ b/src/main/java/com/papercraft/config/VNPAYConfig.java
@@ -5,7 +5,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.util.Random;
 
 public class VNPAYConfig {
     public static final String vnp_TmnCode = "4AP6RXHS";
@@ -21,7 +20,7 @@ public class VNPAYConfig {
         StringBuilder url = new StringBuilder();
         url.append(scheme).append("://").append(serverName);
 
-        if (serverPort != 80) {
+        if (serverPort != 80 && serverPort != 443) {
             url.append(":").append(serverPort);
         }
         url.append(contextPath).append("/vnpay-return");
@@ -54,19 +53,9 @@ public class VNPAYConfig {
 
     public static String getIpAddress(HttpServletRequest request) {
         String ip = request.getHeader("X-FORWARDED-FOR");
-        if (ip ==null) {
+        if (ip == null) {
             ip = request.getRemoteAddr();
         }
         return ip;
-    }
-
-    public static String getRandomNumber(int length) {
-        Random random = new Random();
-        String chars = "0123456789";
-        StringBuffer sb = new StringBuffer(length);
-        for (int i = 0; i < length; i++) {
-            sb.append(chars.charAt(random.nextInt(chars.length())));
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/com/papercraft/config/VNPAYConfig.java
+++ b/src/main/java/com/papercraft/config/VNPAYConfig.java
@@ -24,6 +24,8 @@ public class VNPAYConfig {
         if (serverPort != 80) {
             url.append(":").append(serverPort);
         }
+        url.append(contextPath).append("/vnpay-return");
+
         return url.toString();
     }
 

--- a/src/main/java/com/papercraft/config/VNPAYConfig.java
+++ b/src/main/java/com/papercraft/config/VNPAYConfig.java
@@ -1,0 +1,70 @@
+package com.papercraft.config;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Random;
+
+public class VNPAYConfig {
+    public static final String vnp_TmnCode = "4AP6RXHS";
+    public static final String vnp_HashSecret = "R5FL6HKTPEGFUVNK1VSO7DHT1M6CB2Q5";
+    public static final String vnp_Url = "https://sandbox.vnpayment.vn/paymentv2/vpcpay.html";
+
+    public static String getReturnUrl(HttpServletRequest request) {
+        String scheme = request.getScheme();
+        String serverName = request.getServerName();
+        int serverPort = request.getServerPort();
+        String contextPath = request.getContextPath();
+
+        StringBuilder url = new StringBuilder();
+        url.append(scheme).append("://").append(serverName);
+
+        if (serverPort != 80) {
+            url.append(":").append(serverPort);
+        }
+        return url.toString();
+    }
+
+    public static String hmacSHA512(final String key, final String data) {
+        try {
+            if (key == null || data == null) {
+                throw new Exception();
+            }
+            final Mac hcmacSHA512 = Mac.getInstance("HmacSHA512");
+            byte[] hcmacKeyBytes = key.getBytes(StandardCharsets.UTF_8);
+            final SecretKeySpec secretKey = new SecretKeySpec(hcmacKeyBytes, "HmacSHA512");
+            hcmacSHA512.init(secretKey);
+            byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+            byte[] result = hcmacSHA512.doFinal(dataBytes);
+
+            StringBuilder sb = new StringBuilder();
+            for (byte b : result) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "";
+        }
+    }
+
+    public static String getIpAddress(HttpServletRequest request) {
+        String ip = request.getHeader("X-FORWARDED-FOR");
+        if (ip ==null) {
+            ip = request.getRemoteAddr();
+        }
+        return ip;
+    }
+
+    public static String getRandomNumber(int length) {
+        Random random = new Random();
+        String chars = "0123456789";
+        StringBuffer sb = new StringBuffer(length);
+        for (int i = 0; i < length; i++) {
+            sb.append(chars.charAt(random.nextInt(chars.length())));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
+++ b/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
@@ -1,6 +1,7 @@
 package com.papercraft.controller.api;
 
 import com.papercraft.config.VNPAYConfig;
+import com.papercraft.dao.OrderDAO;
 import com.papercraft.dao.PaymentDAO;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
@@ -44,6 +45,13 @@ public class VNPAYReturnServlet extends HttpServlet {
 
                 response.sendRedirect(request.getContextPath() + "/order-success");
             } else {
+                String orderIdStr = request.getParameter("vnp_TxnRef");
+                if (orderIdStr != null && !orderIdStr.isEmpty()) {
+                    int orderId = Integer.parseInt(orderIdStr);
+
+                    OrderDAO orderDAO = new OrderDAO();
+                    orderDAO.updateOrderStatus(orderId, "canceled");
+                }
                 request.getSession().setAttribute("error", "Giao dịch VNPAY đã bị hủy hoặc không thành công");
                 response.sendRedirect(request.getContextPath() + "/cart");
             }

--- a/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
+++ b/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
@@ -3,6 +3,7 @@ package com.papercraft.controller.api;
 import com.papercraft.config.VNPAYConfig;
 import com.papercraft.dao.OrderDAO;
 import com.papercraft.dao.PaymentDAO;
+import com.papercraft.service.OrderService;
 import jakarta.servlet.annotation.WebServlet;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,21 +37,26 @@ public class VNPAYReturnServlet extends HttpServlet {
         String signValue = hashAllFields(fields);
         if (signValue.equals(vnp_SecureHash)) {
             if ("00".equals(request.getParameter("vnp_TransactionStatus"))) {
-                String orderIdStr = request.getParameter("vnp_TxnRef");
-                String transactionNo = request.getParameter("vnp_TransactionNo");
-                int orderId = Integer.parseInt(orderIdStr);
+                try {
+                    String orderIdStr = request.getParameter("vnp_TxnRef");
+                    String transactionNo = request.getParameter("vnp_TransactionNo");
+                    int orderId = Integer.parseInt(orderIdStr);
 
-                PaymentDAO paymentDAO = new PaymentDAO();
-                paymentDAO.verifyPaymentSuccess(orderId, transactionNo);
+                    PaymentDAO paymentDAO = new PaymentDAO();
+                    paymentDAO.verifyPaymentSuccess(orderId, transactionNo);
 
-                response.sendRedirect(request.getContextPath() + "/order-success");
+                    response.sendRedirect(request.getContextPath() + "/order-success");
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    request.getSession().setAttribute("error", "Thanh toán thành công tại VNPAY nhưng hệ thống gặp sự cố cập nhật. Vui lòng liên hệ Admin kèm mã VNPAY: " + request.getParameter("vnp_TransactionNo"));
+                    response.sendRedirect(request.getContextPath() + "/cart");
+                }
             } else {
                 String orderIdStr = request.getParameter("vnp_TxnRef");
                 if (orderIdStr != null && !orderIdStr.isEmpty()) {
                     int orderId = Integer.parseInt(orderIdStr);
-
-                    OrderDAO orderDAO = new OrderDAO();
-                    orderDAO.updateOrderStatus(orderId, "canceled");
+                    OrderService orderService = new OrderService();
+                    orderService.cancelOrderAndReleaseStock(orderId);
                 }
                 request.getSession().setAttribute("error", "Giao dịch VNPAY đã bị hủy hoặc không thành công");
                 response.sendRedirect(request.getContextPath() + "/cart");

--- a/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
+++ b/src/main/java/com/papercraft/controller/api/VNPAYReturnServlet.java
@@ -1,0 +1,77 @@
+package com.papercraft.controller.api;
+
+import com.papercraft.config.VNPAYConfig;
+import com.papercraft.dao.PaymentDAO;
+import jakarta.servlet.annotation.WebServlet;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+
+@WebServlet(value = "/vnpay-return")
+public class VNPAYReturnServlet extends HttpServlet {
+    @Override
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        Map<String, String> fields = new HashMap<>();
+        for (Enumeration<String> params = request.getParameterNames(); params.hasMoreElements(); ) {
+            String fieldName = params.nextElement();
+            String fieldValue = request.getParameter(fieldName);
+            if (fieldValue != null && !fieldValue.isEmpty()) {
+                fields.put(fieldName, fieldValue);
+            }
+        }
+
+        String vnp_SecureHash = request.getParameter("vnp_SecureHash");
+        fields.remove("vnp_SecureHashType");
+        fields.remove("vnp_SecureHash");
+
+        String signValue = hashAllFields(fields);
+        if (signValue.equals(vnp_SecureHash)) {
+            if ("00".equals(request.getParameter("vnp_TransactionStatus"))) {
+                String orderIdStr = request.getParameter("vnp_TxnRef");
+                String transactionNo = request.getParameter("vnp_TransactionNo");
+                int orderId = Integer.parseInt(orderIdStr);
+
+                PaymentDAO paymentDAO = new PaymentDAO();
+                paymentDAO.verifyPaymentSuccess(orderId, transactionNo);
+
+                response.sendRedirect(request.getContextPath() + "/order-success");
+            } else {
+                request.getSession().setAttribute("error", "Giao dịch VNPAY đã bị hủy hoặc không thành công");
+                response.sendRedirect(request.getContextPath() + "/cart");
+            }
+        } else {
+            request.getSession().setAttribute("error", "Lỗi bảo mật: Sai chữ ký xác thực từ VNPAY");
+            response.sendRedirect(request.getContextPath() + "/cart");
+        }
+    }
+
+    private String hashAllFields(Map<String, String> fields) {
+        Map<String, String> sortedFields = new TreeMap<>(fields);
+        StringBuilder hashData = new StringBuilder();
+
+        for (Map.Entry<String, String> entry : sortedFields.entrySet()) {
+            String fieldName = entry.getKey();
+            String fieldValue = entry.getValue();
+            if (fieldValue != null && !fieldValue.isEmpty()) {
+                hashData.append(fieldName);
+                hashData.append("=");
+                hashData.append(URLEncoder.encode(fieldValue, StandardCharsets.US_ASCII));
+                hashData.append("&");
+            }
+        }
+
+        if (!hashData.isEmpty()) {
+            hashData.setLength(hashData.length() - 1);
+        }
+
+        return VNPAYConfig.hmacSHA512(VNPAYConfig.vnp_HashSecret, hashData.toString());
+    }
+}

--- a/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
+++ b/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
@@ -1,5 +1,6 @@
 package com.papercraft.controller.client;
 
+import com.papercraft.config.VNPAYConfig;
 import com.papercraft.dao.AddressDAO;
 import com.papercraft.dao.CartDAO;
 import com.papercraft.dao.UserVoucherDAO;
@@ -15,21 +16,20 @@ import jakarta.servlet.http.HttpSession;
 
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.*;
 
 @WebServlet("/checkout")
 public class CheckoutServlet extends HttpServlet {
 
     @Override
-    protected void doGet(HttpServletRequest request, HttpServletResponse response)
-            throws ServletException, IOException {
+    protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
 
         HttpSession session = request.getSession();
 
-        //Kiểm tra Login
+        // Kiểm tra Login
         if (session.getAttribute("acc") == null) {
             response.sendRedirect(request.getContextPath() + "/login?redirect=/checkout");
             return;
@@ -49,10 +49,10 @@ public class CheckoutServlet extends HttpServlet {
 
 
         String selectedIdsRaw = request.getParameter("selectedIds");
-        Set<Integer> selectedIds= parseSelectedIdSet(selectedIdsRaw);
+        Set<Integer> selectedIds = parseSelectedIdSet(selectedIdsRaw);
 
-        if (selectedIds.isEmpty()){
-            response.sendRedirect(request.getContextPath()+ "/cart");
+        if (selectedIds.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + "/cart");
             return;
         }
 
@@ -60,28 +60,27 @@ public class CheckoutServlet extends HttpServlet {
         Address userAddr = addressDAO.findDefaultAddress(user.getId());
         request.setAttribute("addr", userAddr);
 
-//        UserVoucherDAO  userVoucherDAO = new UserVoucherDAO();
-//        List<Voucher> vouchers = userVoucherDAO.getVouchersByUserId(user.getId());
-//        request.setAttribute("vouchers", vouchers);
-//
-//        String voucherCode=request.getParameter("voucherCode");
-//        if(voucherCode!=null&&!voucherCode.trim().isEmpty()){
-//            Voucher voucher=new VoucherDAO().getVoucherByCode(voucherCode.trim());
-//            if(voucher==null){
-//                request.setAttribute("saveVoucherError", "Mã voucher không tồn tại");
-//            }else if(!voucher.isAvailable()){
-//                request.setAttribute("saveVoucherError", "Voucher hiện không khả dụng");
-//            }else{
-//                boolean success= userVoucherDAO.addUserVoucher(user.getId(), voucher.getId());
-//                if(!success){
-//                    request.setAttribute("saveVoucherError", "Bạn đã lưu voucher này rồi");
-//                }else{
-//                    request.setAttribute("saveVoucherSuccess", "Áp dụng voucher thành công");
-//                    request.setAttribute("selectedVoucher",voucher);
-//                }
-//            }
-//        }
+        UserVoucherDAO userVoucherDAO = new UserVoucherDAO();
+        List<Voucher> vouchers = userVoucherDAO.getVouchersByUserId(user.getId());
+        request.setAttribute("vouchers", vouchers);
 
+        String voucherCode = request.getParameter("voucherCode");
+        if (voucherCode != null && !voucherCode.trim().isEmpty()) {
+            Voucher voucher = new VoucherDAO().getVoucherByCode(voucherCode.trim());
+            if (voucher == null) {
+                request.setAttribute("saveVoucherError", "Mã voucher không tồn tại");
+            } else if (!voucher.isAvailable()) {
+                request.setAttribute("saveVoucherError", "Voucher hiện không khả dụng");
+            } else {
+                boolean success = userVoucherDAO.addUserVoucher(user.getId(), voucher.getId());
+                if (!success) {
+                    request.setAttribute("saveVoucherError", "Bạn đã lưu voucher này rồi");
+                } else {
+                    request.setAttribute("saveVoucherSuccess", "Áp dụng voucher thành công");
+                    request.setAttribute("selectedVoucher", voucher);
+                }
+            }
+        }
 
         List<OrderItem> items = new ArrayList<>();
         double subTotal = 0;
@@ -89,7 +88,7 @@ public class CheckoutServlet extends HttpServlet {
         for (Product p : cart.list()) {
 
             //nếu sp khng được tick
-            if (!selectedIds.contains(p.getId())){
+            if (!selectedIds.contains(p.getId())) {
                 continue;
             }
 
@@ -109,7 +108,7 @@ public class CheckoutServlet extends HttpServlet {
         }
 
         //nếu selectedId gửi lên không khớp sp trong cart => không cho checkout(về cart )
-        if (items.isEmpty()){
+        if (items.isEmpty()) {
             response.sendRedirect(request.getContextPath() + "/cart");
             return;
         }
@@ -142,11 +141,9 @@ public class CheckoutServlet extends HttpServlet {
                     }
                 }
             } catch (NumberFormatException e) {
-                request.setAttribute("errorVoucher", "Voucher không hợp lệ"
-                );
+                request.setAttribute("errorVoucher", "Voucher không hợp lệ");
             }
         }
-
 
 
         request.setAttribute("items", items);
@@ -156,14 +153,13 @@ public class CheckoutServlet extends HttpServlet {
         request.setAttribute("discountAmount", discountAmount);
         request.setAttribute("grandTotal", grandTotal);
 
-        request.setAttribute("selectedIds",selectedIdsRaw);
+        request.setAttribute("selectedIds", selectedIdsRaw);
 
         request.getRequestDispatcher("/WEB-INF/views/client/payment.jsp").forward(request, response);
     }
 
     @Override
-    protected void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException, ServletException {
+    protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
 
         request.setCharacterEncoding("UTF-8");
         HttpSession session = request.getSession();
@@ -171,25 +167,25 @@ public class CheckoutServlet extends HttpServlet {
         User user = (User) session.getAttribute("acc");
         Cart cart = (Cart) session.getAttribute("cart");
 
-        String selectedIdsRaw= request.getParameter("selectedIds");
-        Set<Integer> selectedIds= parseSelectedIdSet(selectedIdsRaw);
+        String selectedIdsRaw = request.getParameter("selectedIds");
+        Set<Integer> selectedIds = parseSelectedIdSet(selectedIdsRaw);
 
         if (user == null || cart == null || cart.list().isEmpty()) {
             response.sendRedirect(request.getContextPath() + "/cart");
             return;
         }
 
-        if (selectedIds.isEmpty()){
-            response.sendRedirect(request.getContextPath()+ "/cart");
+        if (selectedIds.isEmpty()) {
+            response.sendRedirect(request.getContextPath() + "/cart");
             return;
         }
-        Cart selectedCart= new Cart();
-        for (Product p: cart.list()){
-            if (selectedIds.contains(p.getId())){
+        Cart selectedCart = new Cart();
+        for (Product p : cart.list()) {
+            if (selectedIds.contains(p.getId())) {
                 selectedCart.put(p);
             }
         }
-        if (selectedCart.list().isEmpty()){
+        if (selectedCart.list().isEmpty()) {
             response.sendRedirect(request.getContextPath() + "/cart");
             return;
         }
@@ -262,7 +258,6 @@ public class CheckoutServlet extends HttpServlet {
         }
 
 
-
         Order order = new Order();
         order.setShippingName(fullname);
         order.setShippingPhone(phone);
@@ -274,9 +269,9 @@ public class CheckoutServlet extends HttpServlet {
 //        order.setShippingProvider("GHN");
 //        order.setShippingFee(BigDecimal.valueOf(30000));
 
-        order.setNote(note ==null ? "": note.trim());
+        order.setNote(note == null ? "" : note.trim());
 
-        if (paymentMethod ==null || paymentMethod.isBlank()){
+        if (paymentMethod == null || paymentMethod.isBlank()) {
             paymentMethod = "COD";
         }
 
@@ -292,14 +287,68 @@ public class CheckoutServlet extends HttpServlet {
             }
 
             session.setAttribute("cart", cart);
-
-            // Cho phép vào trang /orderSuccess
             session.setAttribute("orderSuccess", true);
-
-            // Lưu orderId vừa đặt
             session.setAttribute("lastOrderId", orderId);
 
-            response.sendRedirect(request.getContextPath() + "/order-success");
+            if ("VNPAY".equals(paymentMethod)) {
+                long amount = order.getTotalPrice().longValue() * 100;
+
+                Map<String, String> vnp_Params = new HashMap<>();
+                vnp_Params.put("vnp_Version", "2.1.0");
+                vnp_Params.put("vnp_Command", "pay");
+                vnp_Params.put("vnp_TmnCode", VNPAYConfig.vnp_TmnCode);
+                vnp_Params.put("vnp_Amount", String.valueOf(amount));
+                vnp_Params.put("vnp_CurrCode", "VND");
+                vnp_Params.put("vnp_TxnRef", String.valueOf(orderId));
+                vnp_Params.put("vnp_OrderInfo", "Thanh toán đơn hàng" + orderId);
+                vnp_Params.put("vnp_OrderType", "other");
+                vnp_Params.put("vnp_Locale", "vn");
+                vnp_Params.put("vnp_ReturnUrl", VNPAYConfig.getReturnUrl(request));
+                vnp_Params.put("vnp_IpAddr", VNPAYConfig.getIpAddress(request));
+
+                Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/GMT+7"));
+                SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
+                String vnp_CreateDate = formatter.format(calendar.getTime());
+                vnp_Params.put("vnp_CreateDate", vnp_CreateDate);
+
+                calendar.add(Calendar.MINUTE, 15);
+                String vnp_ExpireDate = formatter.format(calendar.getTime());
+                vnp_Params.put("vnp_ExpireDate", vnp_ExpireDate);
+
+                List fieldNames = new ArrayList(vnp_Params.keySet());
+                Collections.sort(fieldNames);
+
+                StringBuilder hashData = new StringBuilder();
+                StringBuilder query = new StringBuilder();
+                Iterator itr = fieldNames.iterator();
+                while (itr.hasNext()) {
+                    String fieldName = (String) itr.next();
+                    String fieldValue = vnp_Params.get(fieldName);
+                    if (fieldName != null && !fieldName.isEmpty()) {
+                        hashData.append(fieldName);
+                        hashData.append('=');
+                        hashData.append(URLEncoder.encode(fieldValue, StandardCharsets.US_ASCII));
+
+                        query.append(URLEncoder.encode(fieldName, StandardCharsets.US_ASCII));
+                        query.append('=');
+                        query.append(URLEncoder.encode(fieldValue, StandardCharsets.US_ASCII));
+
+                        if (itr.hasNext()) {
+                            query.append('&');
+                            hashData.append('&');
+                        }
+                    }
+                }
+
+                String queryUrl = query.toString();
+                String vnp_SecureHash = VNPAYConfig.hmacSHA512(VNPAYConfig.vnp_HashSecret, hashData.toString());
+                queryUrl += "&vnp_SecureHash=" + vnp_SecureHash;
+
+                String paymentUrl = VNPAYConfig.vnp_Url + "?" + queryUrl;
+                response.sendRedirect(paymentUrl);
+            } else {
+                response.sendRedirect(request.getContextPath() + "/order-success");
+            }
         } else {
             request.setAttribute("error", "Đặt hàng thất bại. Có thể một số sản phẩm không còn đủ tồn kho, vui lòng kiểm tra lại giỏ hàng.");
             doGet(request, response);
@@ -307,19 +356,19 @@ public class CheckoutServlet extends HttpServlet {
     }
 
     //parseSelectedIdSet
-    private Set<Integer> parseSelectedIdSet(String selectedIdsRaw){
+    private Set<Integer> parseSelectedIdSet(String selectedIdsRaw) {
         Set<Integer> result = new HashSet<>();
 
         //check đàu vào rỗng
-        boolean isEmpty= selectedIdsRaw == null || selectedIdsRaw.trim().isEmpty();
-        if (isEmpty){
+        boolean isEmpty = selectedIdsRaw == null || selectedIdsRaw.trim().isEmpty();
+        if (isEmpty) {
             return result;
         }
         //tách chuỗi thành mảng theo ","
-        String[] parts= selectedIdsRaw.split(",");
-        for (String part : parts){
+        String[] parts = selectedIdsRaw.split(",");
+        for (String part : parts) {
             String trimmed = part.trim();
-            if (trimmed.matches("\\d+")){
+            if (trimmed.matches("\\d+")) {
                 result.add(Integer.parseInt(trimmed));
             }
         }

--- a/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
+++ b/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
@@ -1,5 +1,6 @@
 package com.papercraft.controller.client;
 
+import com.papercraft.config.MomoConfig;
 import com.papercraft.config.VNPAYConfig;
 import com.papercraft.dao.AddressDAO;
 import com.papercraft.dao.CartDAO;
@@ -14,8 +15,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpSession;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.math.BigDecimal;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
@@ -298,20 +304,20 @@ public class CheckoutServlet extends HttpServlet {
             // Lưu orderId vừa đặt
             session.setAttribute("lastOrderId", orderId);
 
-            if ("VNPAY".equals(paymentMethod)) {
-                double calculatedSubTotal = selectedCart.total();
-                double calculatedVat = Math.round(calculatedSubTotal * 0.05);
-                double calculatedGrandTotal = Math.round(calculatedSubTotal + calculatedVat + shippingFee.doubleValue());
+            double calculatedSubTotal = selectedCart.total();
+            double calculatedVat = Math.round(calculatedSubTotal * 0.05);
+            double calculatedGrandTotal = Math.round(calculatedSubTotal + calculatedVat + shippingFee.doubleValue());
 
-                if (voucherIdRaw != null && !voucherIdRaw.isBlank()) {
-                    VoucherDAO voucherDAO = new VoucherDAO();
-                    Voucher v = voucherDAO.getVoucherById(Integer.parseInt(voucherIdRaw));
-                    if (v != null) {
-                        calculatedGrandTotal = v.applyDiscount(BigDecimal.valueOf(calculatedGrandTotal)).doubleValue();
-                    }
+            if (voucherIdRaw != null && !voucherIdRaw.isBlank()) {
+                VoucherDAO voucherDAO = new VoucherDAO();
+                Voucher v = voucherDAO.getVoucherById(Integer.parseInt(voucherIdRaw));
+                if (v != null) {
+                    calculatedGrandTotal = v.applyDiscount(BigDecimal.valueOf(calculatedGrandTotal)).doubleValue();
                 }
-                long amount = (long) calculatedGrandTotal * 100;
+            }
 
+            if ("VNPAY".equals(paymentMethod)) {
+                long amount = (long) calculatedGrandTotal * 100;
                 Map<String, String> vnp_Params = new HashMap<>();
                 vnp_Params.put("vnp_Version", "2.1.0");
                 vnp_Params.put("vnp_Command", "pay");
@@ -319,7 +325,7 @@ public class CheckoutServlet extends HttpServlet {
                 vnp_Params.put("vnp_Amount", String.valueOf(amount));
                 vnp_Params.put("vnp_CurrCode", "VND");
                 vnp_Params.put("vnp_TxnRef", String.valueOf(orderId));
-                vnp_Params.put("vnp_OrderInfo", "Thanh toan don hang" + orderId);
+                vnp_Params.put("vnp_OrderInfo", "Thanh toan don hang " + orderId);
                 vnp_Params.put("vnp_OrderType", "other");
                 vnp_Params.put("vnp_Locale", "vn");
                 vnp_Params.put("vnp_ReturnUrl", VNPAYConfig.getReturnUrl(request));
@@ -365,6 +371,82 @@ public class CheckoutServlet extends HttpServlet {
 
                 String paymentUrl = VNPAYConfig.vnp_Url + "?" + queryUrl;
                 response.sendRedirect(paymentUrl);
+            } else if ("MOMO".equals(paymentMethod)) {
+                String amount = String.valueOf((long) calculatedGrandTotal);
+                String momoOrderId = orderId + "_" + System.currentTimeMillis();
+                String requestId = String.valueOf(System.currentTimeMillis());
+                String orderInfo = "Thanh toan don hang " + orderId;
+                String returnUrl = MomoConfig.getReturnUrl(request);
+                String ipnUrl = MomoConfig.getIpnUrl(request);
+                String requestType = "captureWallet";
+                String extraData = "";
+
+                String rawHash = "accessKey=" + MomoConfig.accessKey +
+                        "&amount=" + amount +
+                        "&extraData=" + extraData +
+                        "&ipnUrl=" + ipnUrl +
+                        "&orderId=" + momoOrderId +
+                        "&orderInfo=" + orderInfo +
+                        "&partnerCode=" + MomoConfig.partnerCode +
+                        "&redirectUrl=" + returnUrl +
+                        "&requestId=" + requestId +
+                        "&requestType=" + requestType;
+
+                String signature = MomoConfig.hcmacSHA256(MomoConfig.secretKey, rawHash);
+
+                String jsonRequest = "{" +
+                        "\"partnerCode\":\"" + MomoConfig.partnerCode + "\"," +
+                        "\"partnerName\":\"PaperCraft\"," +
+                        "\"storeId\":\"MomoTestStore\"," +
+                        "\"requestId\":\"" + requestId + "\"," +
+                        "\"amount\":" + amount + "," +
+                        "\"orderId\":\"" + momoOrderId + "\"," +
+                        "\"orderInfo\":\"" + orderInfo + "\"," +
+                        "\"redirectUrl\":\"" + returnUrl + "\"," +
+                        "\"ipnUrl\":\"" + ipnUrl + "\"," +
+                        "\"lang\":\"vi\"," +
+                        "\"requestType\":\"" + requestType + "\"," +
+                        "\"autoCapture\":true," +
+                        "\"extraData\":\"" + extraData + "\"," +
+                        "\"signature\":\"" + signature + "\"" +
+                        "}";
+
+                // Gọi API momo
+                URL url = new URL(MomoConfig.momo_Url);
+                HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                conn.setRequestMethod("POST");
+                conn.setRequestProperty("Content-Type", "application/json; charset=UTF-8");
+                conn.setDoOutput(true);
+
+                // Đọc dữ liệu trả về từ momo
+                try (OutputStream os = conn.getOutputStream()) {
+                    byte[] input = jsonRequest.getBytes(StandardCharsets.UTF_8);
+                    os.write(input, 0, input.length);
+                }
+                StringBuilder responseStr = new StringBuilder();
+                try (BufferedReader br = new BufferedReader(new InputStreamReader(conn.getInputStream(), StandardCharsets.UTF_8))) {
+                    String responseLine;
+                    while ((responseLine = br.readLine()) != null) {
+                        responseStr.append(responseLine.trim());
+                    }
+                }
+
+                String resultJson = responseStr.toString();
+                String payUrl = "";
+                int payUrlIndex = resultJson.indexOf("\"payUrl\":\"");
+                if (payUrlIndex != -1) {
+                    int start = payUrlIndex + 10;
+                    int end = resultJson.indexOf("\"", start);
+                    payUrl = resultJson.substring(start, end);
+                }
+
+                if (!payUrl.isEmpty()) {
+                    response.sendRedirect(payUrl);
+                } else {
+                    System.out.println("MoMo API Error Response: " + resultJson); // debug
+                    request.getSession().setAttribute("error", "Lỗi tạo giao dịch MoMo. Hệ thống đang bảo trì!");
+                    response.sendRedirect(request.getContextPath() + "/cart");
+                }
             } else {
                 response.sendRedirect(request.getContextPath() + "/order-success");
             }

--- a/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
+++ b/src/main/java/com/papercraft/controller/client/CheckoutServlet.java
@@ -146,7 +146,6 @@ public class CheckoutServlet extends HttpServlet {
             }
         }
 
-
         request.setAttribute("items", items);
         request.setAttribute("subTotal", subTotal);
         request.setAttribute("vat", vat);
@@ -191,7 +190,6 @@ public class CheckoutServlet extends HttpServlet {
             return;
         }
 
-
         String fullname = request.getParameter("fullname");
         String phone = request.getParameter("phone");
         String note = request.getParameter("note");
@@ -209,7 +207,6 @@ public class CheckoutServlet extends HttpServlet {
             int voucherId = Integer.parseInt(voucherIdRaw);
             session.setAttribute("voucherId", voucherId);
         }
-
 
         StringBuilder fullAddressBuilder = new StringBuilder();
 
@@ -302,7 +299,18 @@ public class CheckoutServlet extends HttpServlet {
             session.setAttribute("lastOrderId", orderId);
 
             if ("VNPAY".equals(paymentMethod)) {
-                long amount = order.getTotalPrice().longValue() * 100;
+                double calculatedSubTotal = selectedCart.total();
+                double calculatedVat = Math.round(calculatedSubTotal * 0.05);
+                double calculatedGrandTotal = Math.round(calculatedSubTotal + calculatedVat + shippingFee.doubleValue());
+
+                if (voucherIdRaw != null && !voucherIdRaw.isBlank()) {
+                    VoucherDAO voucherDAO = new VoucherDAO();
+                    Voucher v = voucherDAO.getVoucherById(Integer.parseInt(voucherIdRaw));
+                    if (v != null) {
+                        calculatedGrandTotal = v.applyDiscount(BigDecimal.valueOf(calculatedGrandTotal)).doubleValue();
+                    }
+                }
+                long amount = (long) calculatedGrandTotal * 100;
 
                 Map<String, String> vnp_Params = new HashMap<>();
                 vnp_Params.put("vnp_Version", "2.1.0");
@@ -311,14 +319,14 @@ public class CheckoutServlet extends HttpServlet {
                 vnp_Params.put("vnp_Amount", String.valueOf(amount));
                 vnp_Params.put("vnp_CurrCode", "VND");
                 vnp_Params.put("vnp_TxnRef", String.valueOf(orderId));
-                vnp_Params.put("vnp_OrderInfo", "Thanh toán đơn hàng" + orderId);
+                vnp_Params.put("vnp_OrderInfo", "Thanh toan don hang" + orderId);
                 vnp_Params.put("vnp_OrderType", "other");
                 vnp_Params.put("vnp_Locale", "vn");
                 vnp_Params.put("vnp_ReturnUrl", VNPAYConfig.getReturnUrl(request));
                 vnp_Params.put("vnp_IpAddr", VNPAYConfig.getIpAddress(request));
 
                 Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("Etc/GMT+7"));
-                SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy");
+                SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMddHHmmss");
                 String vnp_CreateDate = formatter.format(calendar.getTime());
                 vnp_Params.put("vnp_CreateDate", vnp_CreateDate);
 

--- a/src/main/java/com/papercraft/dao/OrderDAO.java
+++ b/src/main/java/com/papercraft/dao/OrderDAO.java
@@ -240,8 +240,6 @@ public class OrderDAO {
                 }
 
             }
-
-
         } catch (SQLException e) {
             e.printStackTrace();
         } catch (Exception e) {

--- a/src/main/java/com/papercraft/dao/OrderDAO.java
+++ b/src/main/java/com/papercraft/dao/OrderDAO.java
@@ -252,7 +252,7 @@ public class OrderDAO {
 
     public int insertOrder(Connection conn, Order order) throws SQLException {
         String sql = """
-                        INSERT INTO orders (user_id, status, total_price, note, shipping_fee,shipping_provider, shipping_name, shipping_phone, shipping_address)
+                        INSERT INTO orders (user_id, status, total_price, note, shipping_fee, shipping_provider, shipping_name, shipping_phone, shipping_address)
                         VALUES (?, ?, ?, ? ,?, ?, ?, ?,?)
                 """;
 

--- a/src/main/java/com/papercraft/service/OrderService.java
+++ b/src/main/java/com/papercraft/service/OrderService.java
@@ -9,6 +9,8 @@ import com.papercraft.utils.DBConnect;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
@@ -146,6 +148,89 @@ public class OrderService {
                 } catch (SQLException e) {
                     e.printStackTrace();
                 }
+            }
+        }
+    }
+
+    // Rollback khi đơn hàng bị hủy hoặc lỗi
+    public boolean cancelOrderAndReleaseStock(int orderId) {
+        Connection conn = null;
+        PreparedStatement psUpdateOrder = null;
+        PreparedStatement psGetItems = null;
+        PreparedStatement psUpdateStock = null;
+        ResultSet rs = null;
+
+        try {
+            conn = DBConnect.getConnection();
+            conn.setAutoCommit(false);
+
+            String updateOrderSql = "UPDATE orders SET status = 'canceled' WHERE id = ?";
+            psUpdateOrder = conn.prepareStatement(updateOrderSql);
+            psUpdateOrder.setInt(1, orderId);
+            int orderUpdated = psUpdateOrder.executeUpdate();
+
+            if (orderUpdated == 0) {
+                conn.rollback();
+                return false;
+            }
+
+            String getItemsSql = "SELECT product_id, quantity FROM order_item WHERE order_id = ?";
+            psGetItems = conn.prepareStatement(getItemsSql);
+            psGetItems.setInt(1, orderId);
+            rs = psGetItems.executeQuery();
+
+            List<OrderItem> itemsToRestore = new ArrayList<>();
+            while (rs.next()) {
+                OrderItem item = new OrderItem();
+                item.setProductId(rs.getInt("product_id"));
+                item.setQuantity(rs.getInt("quantity"));
+                itemsToRestore.add(item);
+            }
+
+            String updateStockSql = "UPDATE product SET stock_quantity = stock_quantity + ? WHERE id = ?";
+            psUpdateStock = conn.prepareStatement(updateStockSql);
+            for (OrderItem item : itemsToRestore) {
+                psUpdateStock.setInt(1, item.getQuantity());
+                psUpdateStock.setInt(2, item.getProductId());
+                psUpdateStock.addBatch();
+            }
+            psUpdateStock.executeBatch();
+
+            conn.commit();
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            if (conn != null) {
+                try {
+                    conn.rollback();
+                } catch (SQLException ex) {
+                    ex.printStackTrace();
+                }
+            }
+            return false;
+        } finally {
+            try {
+                if (rs != null) rs.close();
+            } catch (Exception e) {
+            }
+            try {
+                if (psUpdateOrder != null) psUpdateOrder.close();
+            } catch (Exception e) {
+            }
+            try {
+                if (psGetItems != null) psGetItems.close();
+            } catch (Exception e) {
+            }
+            try {
+                if (psUpdateStock != null) psUpdateStock.close();
+            } catch (Exception e) {
+            }
+            try {
+                if (conn != null) {
+                    conn.setAutoCommit(true);
+                    conn.close();
+                }
+            } catch (Exception e) {
             }
         }
     }

--- a/src/main/webapp/WEB-INF/views/admin/admin-order-view.jsp
+++ b/src/main/webapp/WEB-INF/views/admin/admin-order-view.jsp
@@ -32,7 +32,7 @@
             <!-- -------------UP--------- -->
             <section class="up">
                 <div class="back">
-                    <a id="icon-back" href=..admin/admin-order-manage"><i
+                    <a id="icon-back" href="javascript:history.back()"><i
                             class="fa-solid fa-arrow-left"></i></a>
                     <h1> Chi Tiết Đơn Hàng</h1>
                 </div>

--- a/src/main/webapp/WEB-INF/views/client/cart.jsp
+++ b/src/main/webapp/WEB-INF/views/client/cart.jsp
@@ -24,6 +24,13 @@
 <jsp:include page="../includes/header.jsp"/>
 
 <!-- =================MAIN===================== -->
+<c:if test="${not empty sessionScope.error}">
+    <div style="background-color: indianred; color: red; padding: 12px 20px; margin: 15px 0; display: flex; align-items: center; gap: 10px;">
+        <i class="fa-solid fa-circle-exclamation"></i>
+        <span>${sessionScope.error}</span>
+    </div>
+    <c:remove var="error" scope="session"/>
+</c:if>
 
 <!-- ============CART EMPTY================ -->
 <c:if test="${empty items}">
@@ -43,7 +50,7 @@
 <c:if test="${not empty items}">
     <main class="cart-fill-main">
         <div class="cart-banner">
-            <marquee scrollamount="8">💡 Phí vận chuyển sẽ được cập nhật sau khi bạn xác nhập địa chỉ </marquee>
+            <marquee scrollamount="8">💡 Phí vận chuyển sẽ được cập nhật sau khi bạn xác nhập địa chỉ</marquee>
         </div>
 
         <div class="container">

--- a/src/main/webapp/WEB-INF/views/client/payment.jsp
+++ b/src/main/webapp/WEB-INF/views/client/payment.jsp
@@ -223,7 +223,7 @@
                     </tfoot>
                 </table>
 
-                <%--                //shipping Provider--%>
+                <%--shipping Provider--%>
                 <div class="shipping-method">
                     <h3>Vận chuyển:</h3>
 

--- a/src/main/webapp/WEB-INF/views/client/payment.jsp
+++ b/src/main/webapp/WEB-INF/views/client/payment.jsp
@@ -256,17 +256,8 @@
                     </div>
 
                     <div class="method bank-method">
-                        <input type="radio" name="paymentMethod" id="bankCard" value="BANK">
-                        <label for="bankCard" style="font-weight: bold; margin-left: 5px;">Chuyển khoản Ngân
-                            hàng</label>
-
-                        <button type="button" class="toggle-btn"><i class="fa-solid fa-plus"></i></button>
-
-                        <div class="hidden-content" style="display: none; margin-top: 10px;">
-                            <p>Vui lòng chuyển khoản đến STK sau:</p>
-                            <p><b>Vietcombank - 0123456789 - PAPER CRAFT</b></p>
-                            <p>Nội dung: <b>SDT_DAT_HANG</b></p>
-                        </div>
+                        <input type="radio" name="paymentMethod" id="VNPAY" value="VNPAY">
+                        <label for="VNPAY" style="font-weight: bold; margin-left: 5px;">Thanh toán bằng VNPAY</label>
                     </div>
 
                     <div class="method momo-method">

--- a/src/main/webapp/js/analytics.js
+++ b/src/main/webapp/js/analytics.js
@@ -139,7 +139,7 @@ export function initializeAnalytics(contextPath) {
                             <td>${item.currentStock}</td>
                             <td>${item.totalImported}</td>
                             <td>${item.totalSold}</td>
-                            <td>${item.dailySalesVelocity}</td>
+                            <td>${item.dailySalesVelocity.toFixed(1)}</td>
                             <td><small style="font-weight: 600; color: ${status.color}">${consumptionRate.toFixed(1)}%</small></td>
                             <td><strong>${item.recommendedImportQty}</strong></td>
                             <td><span class="${status.class}">${status.text}</span></td>


### PR DESCRIPTION
**Tổng quan**
PR này hoàn thiện tính năng tích hợp cổng thanh toán VNPAY & Momo cho hệ thống PaperCraft. Đảm bảo toàn vẹn dữ liệu hệ thống (Data Integrity) giữa trạng thái đơn hàng và số lượng hàng tồn kho khi xảy ra các kịch bản hủy giao dịch hoặc giao dịch thất bại.

**Các thay đổi chính** 
1. VNPAY:
- Tích hợp VNPAY URL (Task 1-4): Xây dựng cấu hình và tạo luồng chuyển hướng người dùng sang cổng sandbox VNPAY.
- Xử lý kết quả trả về (`VNPAYReturnServlet`): Nhận phản hồi, giải mã và xác thực chữ ký bảo mật `vnp_SecureHash` từ VNPAY.
- Quản lý Database Transaction (`OrderService`): Phát triển hàm `cancelOrderAndReleaseStock` gộp việc cập nhật trạng thái đơn thành `canceled` và khôi phục số lượng sản phẩm vào kho trong một kết nối duy nhất, đảm bảo tự động rollback nếu gặp lỗi hệ thống.
- Cải thiện UI/UX hiển thị lỗi (`cart.jsp`): Thêm khối thông báo lỗi thanh toán từ Session.

2. Momo:
- Tích hợp Momo URL (Phase 1): Xây dựng cấu hình và tạo luồng chuyển hướng người dùng sang cổng sandbox Momo.
-  Xử lý kết quả trả về & Đồng bộ dữ liệu (Phase 2):  Tạo MomoReturnServlet để tiếp nhận phản hồi từ MoMo (redirectUrl). Xác thực tính hợp lệ của chữ ký phản hồi từ MoMo để tránh giả mạo dữ liệu. Trường hợp thành công (resultCode = 0): Gọi PaymentDAO để xác nhận đơn đã thanh toán.

Trường hợp thất bại/Hủy giao dịch (resultCode != 0): Gọi hàm orderService.cancelOrderAndReleaseStock(orderId) để chuyển trạng thái đơn sang canceled và hoàn lại số lượng hàng vào kho.

**Kịch bản kiểm thử** 
1. Thanh toán thành công: Giỏ hàng thanh toán qua VNPAY -> Trừ kho -> Trả về `/order-success` -> Đơn hàng cập nhật trạng thái thành công.
2. Khách hàng hủy thanh toán: Tại trang VNPAY Sandbox bấm "Hủy giao dịch" -> Hệ thống trả về trang giỏ hàng -> Hiển thị thông báo lỗi màu đỏ -> Kiểm tra DB thấy đơn đổi sang `canceled` và kho được hoàn trả đầy đủ.

**Issues liên quan**
Closes #98 
Closes #101 